### PR TITLE
fix: build baseUrl

### DIFF
--- a/config/vite.config.prod.ts
+++ b/config/vite.config.prod.ts
@@ -1,9 +1,9 @@
 import { mergeConfig } from 'vite';
-import baseConig from './vite.config.base';
+import baseConfig from './vite.config.base';
 
 export default mergeConfig(
   {
     mode: 'production',
   },
-  baseConig
+  { ...baseConfig, base: '/' }
 );

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "vite --config ./config/vite.config.dev.ts",
     "build": "vue-tsc --noEmit --skipLibCheck && vite build --config ./config/vite.config.prod.ts",
     "lint-staged": "npx lint-staged",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "build:normal": "vite build --config ./config/vite.config.prod.ts"
   },
   "dependencies": {
     "@arco-design/web-vue": "^2.23.0",


### PR DESCRIPTION
问题1：打包构建后，报错信息如下：
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "text/html". Strict MIME type checking is enforced for module scripts per HTML spec.
解决：参考[配置基础](https://cn.vitejs.dev/guide/build.html#public-base-path) ，vite.config.prod.ts下新增基础路径。

问题2：vue-tsc --noEmit --skipLibCheck && vite build --config ./config/vite.config.prod.ts 命令打包报错
解决：新增  build:normal 命令，暂时去除 vue-tsc --noEmit --skipLibCheck